### PR TITLE
perf: preload critical font for LCP improvement

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import "@fontsource-variable/manrope"
+import manropeLatinUrl from "@fontsource-variable/manrope/files/manrope-latin-wght-normal.woff2?url"
 
 const siteUrl = String(Astro.site)
 const image = "https://dappbooster.dev/ogImage.jpg"
@@ -69,6 +70,13 @@ const structuredData = {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="robots" content="index, follow" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      rel="preload"
+      as="font"
+      type="font/woff2"
+      href={manropeLatinUrl}
+      crossorigin
+    />
     <title>
       dAppBooster - Web3 Template For All Your Blockchain Development Needs
     </title>


### PR DESCRIPTION
## Summary

- Import Manrope Latin woff2 font file via Astro's `?url` suffix to get the build-hashed path
- Add `<link rel="preload" as="font" type="font/woff2" crossorigin>` in the `<head>` before CSS
- Eliminates the font discovery delay (browser previously had to parse CSS before requesting the font)
- Estimated LCP improvement: 100-400ms depending on connection speed

## Test plan

- [ ] `pnpm build` passes
- [ ] Built HTML contains `<link rel="preload" ... href="/_astro/manrope-latin-*.woff2">`
- [ ] No duplicate font requests in browser DevTools Network tab