### PR TITLE
fix: improve footer social icon touch targets

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -98,7 +98,7 @@ const socialItems = [
   .socials {
     display: flex;
     align-items: center;
-    gap: calc(var(--space) * 2);
+    gap: var(--space);
     line-height: 0;
     &:before {
       content: "";
@@ -106,6 +106,13 @@ const socialItems = [
       width: 1px;
       height: 1.5rem;
       background: var(--primaryLight);
+    }
+    a {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 44px;
+      min-height: 44px;
     }
   }
   .rightFooter {


### PR DESCRIPTION
## Summary

- Add `min-width: 44px` and `min-height: 44px` to footer social icon links
- Add flexbox centering to keep icons visually centered within the larger touch target
- Reduce gap between social icons to compensate for the increased hit area (was `calc(var(--space) * 2)`, now `var(--space)`)
- Meets WCAG 2.2 Target Size criterion (minimum 44x44px for touch targets)

## Test plan

- [ ] `pnpm build` passes
- [ ] Social icons visually centered, spacing looks natural
- [ ] Touch targets are at least 44x44px (verify in DevTools element inspector)
- [ ] Test on mobile viewport (375px width)